### PR TITLE
Fixed git-hooks

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,7 @@ help:
 
 .PHONY: bootstrap
 bootstrap: ## Bootstrap local environment for first use
-	make git-hooks
+	@make git-hooks
 	pip3 install --user Jinja2 PyYAML boto3
 	@{ \
 		export AWS_PROFILE=$(aws_profile); \
@@ -19,10 +19,9 @@ bootstrap: ## Bootstrap local environment for first use
 
 .PHONY: git-hooks
 git-hooks: ## Set up hooks in .githooks
-	@{ \
-		git submodule update --init .githooks \
-		git config core.hooksPath .githooks \
-	}
+	@git submodule update --init .githooks ; \
+	git config core.hooksPath .githooks \
+
 
 .PHONY: terraform-init
 terraform-init: ## Run `terraform init` from repo root


### PR DESCRIPTION
This resolved the following error when running `make bootstrap`
```
▶ make bootstrap
make git-hooks
bash: -c: line 1: syntax error: unexpected end of file
make[1]: *** [git-hooks] Error 2
make: *** [bootstrap] Error 2
```