### PR TITLE
[DW-4347] Add common tags, including costcode secret

### DIFF
--- a/ci/meta.yml
+++ b/ci/meta.yml
@@ -1,5 +1,18 @@
 meta:
   plan:
+    terraform-common-config:
+      config:
+        platform: linux
+        image_resource:
+          type: docker-image
+          source:
+            repository: ((dataworks.terraform_repository))
+            tag: ((dataworks.terraform_version))
+        params:
+          TF_INPUT: false
+          TF_CLI_ARGS_apply: -lock-timeout=300s
+          TF_CLI_ARGS_plan: -lock-timeout=300s
+          TF_VAR_costcode: ((dataworks.costcode))
     terraform-bootstrap:
       task: terraform-bootstrap
       config:
@@ -26,14 +39,8 @@ meta:
         AWS_REGION: eu-west-2
     terraform-apply:
       task: terraform-apply
+      .: (( inject meta.plan.terraform-common-config ))
       config:
-        platform: linux
-        image_resource:
-          type: docker-image
-          source:
-            repository: hashicorp/terraform
-            version: ((dataworks.terraform_version))
-            tag: ((dataworks.terraform_version))
         run:
           path: sh
           args:
@@ -48,19 +55,10 @@ meta:
         inputs:
           - name: dataworks-repo-template-terraform
           - name: terraform-config
-      params:
-        TF_CLI_ARGS_apply: -lock-timeout=300s
-        TF_INPUT: "false"
     terraform-plan:
       task: terraform-plan
+      .: (( inject meta.plan.terraform-common-config ))
       config:
-        platform: linux
-        image_resource:
-          type: docker-image
-          source:
-            repository: hashicorp/terraform
-            version: ((dataworks.terraform_version))
-            tag: ((dataworks.terraform_version))
         run:
           path: sh
           args:
@@ -74,6 +72,3 @@ meta:
         inputs:
           - name: dataworks-repo-template-terraform
           - name: terraform-config
-      params:
-        TF_CLI_ARGS_plan: -lock-timeout=300s
-        TF_INPUT: "false"

--- a/terraform/deploy/terraform.tf.j2
+++ b/terraform/deploy/terraform.tf.j2
@@ -21,7 +21,7 @@ locals{
     Application  = local.name
     Persistence  = "True"
     AutoShutdown = "False"
-    Costcode     = "{{ var.costcode }}"
+    Costcode     = var.costcode
     Team         = "DataWorks"
   }
 }

--- a/terraform/deploy/terraform.tf.j2
+++ b/terraform/deploy/terraform.tf.j2
@@ -11,3 +11,18 @@ terraform {
   }
 }
 
+locals{
+  common_tags = {
+    {% for key, value in common_tags.items() %}
+      {{key}} = "{{value}}"
+    {% endfor %}
+    Name         = local.name
+    Environment  = local.environment
+    Application  = local.name
+    Persistence  = "True"
+    AutoShutdown = "False"
+    Costcode     = "{{ dataworks_costcode }}"
+    Team         = "DataWorks"
+  }
+}
+

--- a/terraform/deploy/terraform.tf.j2
+++ b/terraform/deploy/terraform.tf.j2
@@ -21,7 +21,7 @@ locals{
     Application  = local.name
     Persistence  = "True"
     AutoShutdown = "False"
-    Costcode     = "{{ dataworks_costcode }}"
+    Costcode     = "{{ var.costcode }}"
     Team         = "DataWorks"
   }
 }

--- a/terraform/deploy/terraform.tfvars.j2
+++ b/terraform/deploy/terraform.tfvars.j2
@@ -1,4 +1,0 @@
-variable costcode {
-    type = string
-    default = ""
-}

--- a/terraform/deploy/terraform.tfvars.j2
+++ b/terraform/deploy/terraform.tfvars.j2
@@ -1,0 +1,4 @@
+variable costcode {
+    type = string
+    default = ""
+}

--- a/terraform/deploy/variables.tf
+++ b/terraform/deploy/variables.tf
@@ -1,0 +1,14 @@
+variable "assume_role" {
+  type    = string
+  default = "ci"
+}
+
+variable "region" {
+  type    = string
+  default = "eu-west-2"
+}
+
+variable "costcode" {
+  type    = string
+  default = ""
+}

--- a/terraform/deploy/variables.tf
+++ b/terraform/deploy/variables.tf
@@ -1,13 +1,3 @@
-variable "assume_role" {
-  type    = string
-  default = "ci"
-}
-
-variable "region" {
-  type    = string
-  default = "eu-west-2"
-}
-
 variable "costcode" {
   type    = string
   default = ""


### PR DESCRIPTION
* Use a terraform_common_config section to inject any common config to all terraform jobs
* Add common tags to terraform.tf locals
* Insert costcode tag at run time from dataworks secrets