### PR TITLE
Add markers for initial-commit.sh run by dataworks-github-config

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,5 @@ In addition, you may want to do the following:
 
 1. Configure Concourse CI pipeline:
     1. Add/remove jobs in `./ci/jobs` as required 
-    1. Enable Terraform plan and apply tasks - update `./ci/meta.yml` as instructed in the comments inside `terraform-plan` and `terraform-apply` sections
     1. Create CI pipeline:  
 `aviator`

--- a/ci/meta.yml
+++ b/ci/meta.yml
@@ -48,10 +48,9 @@ meta:
             - |
               cp ../terraform-bootstrap/terraform.tf .
               terraform workspace show
-              # Remove this line; uncomment the next lines
-              #terraform init
-              #terraform plan -out terraform.plan
-              #terraform apply -auto-approve terraform.plan
+              #ENABLE terraform init
+              #ENABLE terraform plan -out terraform.plan
+              #ENABLE terraform apply -auto-approve terraform.plan
           dir: dataworks-repo-template-terraform
         inputs:
           - name: dataworks-repo-template-terraform
@@ -67,10 +66,9 @@ meta:
             - |
               cp ../terraform-bootstrap/terraform.tf .
               terraform workspace show
-              # Remove this line and the next; uncomment the following lines
-              terraform init -backend=false; terraform validate
-              #terraform init
-              #terraform plan $DETAILED_EXITCODE
+              terraform init -backend=false; terraform validate #REMOVE
+              #ENABLE terraform init
+              #ENABLE terraform plan $DETAILED_EXITCODE
           dir: dataworks-repo-template-terraform
         inputs:
           - name: dataworks-repo-template-terraform

--- a/ci/meta.yml
+++ b/ci/meta.yml
@@ -48,9 +48,9 @@ meta:
             - |
               cp ../terraform-bootstrap/terraform.tf .
               terraform workspace show
-              #ENABLE terraform init
-              #ENABLE terraform plan -out terraform.plan
-              #ENABLE terraform apply -auto-approve terraform.plan
+              #ENABLE_BY_INITIAL_COMMIT terraform init
+              #ENABLE_BY_INITIAL_COMMIT terraform plan -out terraform.plan
+              #ENABLE_BY_INITIAL_COMMIT terraform apply -auto-approve terraform.plan
           dir: dataworks-repo-template-terraform
         inputs:
           - name: dataworks-repo-template-terraform
@@ -66,9 +66,9 @@ meta:
             - |
               cp ../terraform-bootstrap/terraform.tf .
               terraform workspace show
-              terraform init -backend=false; terraform validate #REMOVE
-              #ENABLE terraform init
-              #ENABLE terraform plan $DETAILED_EXITCODE
+              terraform init -backend=false; terraform validate #REMOVE_BY_INITIAL_COMMIT
+              #ENABLE_BY_INITIAL_COMMIT terraform init
+              #ENABLE_BY_INITIAL_COMMIT terraform plan $DETAILED_EXITCODE
           dir: dataworks-repo-template-terraform
         inputs:
           - name: dataworks-repo-template-terraform


### PR DESCRIPTION
Add markers for initial-commit.sh run by dataworks-github-config. These will be used by updated initial-commit.sh in https://github.com/dwp/dataworks-github-config:
1. `#ENABLE_BY_INITIAL_COMMIT` parts will be removed, thus uncommenting the lines containing that marker.
2. Lines with `#DELETE_BY_INITIAL_COMMIT` will be deleted.