### PR TITLE
DW-4490 - Add tf init step to workspace create

### DIFF
--- a/create-workspace.yml
+++ b/create-workspace.yml
@@ -16,6 +16,5 @@ run:
     - -exc
     - |
       echo "Creating workspace $WORKSPACE"
+      terraform init
       terraform workspace new $WORKSPACE
-      terraform workspace init
-

--- a/create-workspace.yml
+++ b/create-workspace.yml
@@ -17,3 +17,5 @@ run:
     - |
       echo "Creating workspace $WORKSPACE"
       terraform workspace new $WORKSPACE
+      terraform workspace init
+

--- a/create-workspace.yml
+++ b/create-workspace.yml
@@ -18,3 +18,4 @@ run:
       echo "Creating workspace $WORKSPACE"
       terraform init
       terraform workspace new $WORKSPACE
+      terraform apply -auto-approve


### PR DESCRIPTION
I believe this is required, as TF doesn't actually create the WorkSpace properly with the process as it stands - it says it does, but when you try and run Concourse against them, it hasn't.

I intercepted a Concourse container and did the additional step of a tf init, and it seems to work OK in Concourse now.

Signed-off-by: Benjamin Sherwood <benjaminsherwood@digital.uc.dwp.gov.uk>