### PR TITLE
input_mapping placed here breaks the pr job

### DIFF
--- a/ci/jobs/pr.yml
+++ b/ci/jobs/pr.yml
@@ -8,8 +8,6 @@ jobs:
         params:
           path: dataworks-repo-template-terraform-pr
           status: pending
-        input_mapping:
-          dataworks-repo-template-terraform: dataworks-repo-template-terraform-pr
       - .: (( inject meta.plan.terraform-bootstrap ))
         input_mapping:
           dataworks-repo-template-terraform: dataworks-repo-template-terraform-pr
@@ -17,8 +15,8 @@ jobs:
         input_mapping:
           dataworks-repo-template-terraform: dataworks-repo-template-terraform-pr
         params:
-          TF_WORKSPACE: 'qa'
-          DETAILED_EXITCODE: ''
+          TF_WORKSPACE: "qa"
+          DETAILED_EXITCODE: ""
         on_failure:
           put: dataworks-repo-template-terraform-pr
           params:


### PR DESCRIPTION
Removed the `input_mapping` lines for the put task, as it's incorrect and breaks the job:
```
error: invalid pipeline config:
invalid jobs:
        jobs.my-pipeline-pr.plan.do[1]: unknown fields ["input_mapping"]
```