### PR TITLE
Fixed so workspace creation works

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -40,4 +40,7 @@ terraform-apply: ## Run `terraform apply` from repo root
 
 .PHONY: terraform-workspace-new
 terraform-workspace-new: ## Creates new Terraform workspace with Concourse remote execution. Run `terraform-workspace-new workspace=<workspace_name>`
+	make bootstrap
+	cp terraform.tf jeff.tf && \
 	fly -t aws-concourse execute --config create-workspace.yml --input repo=. -v workspace="$(workspace)"
+	rm jeff.tf

--- a/Makefile
+++ b/Makefile
@@ -40,7 +40,10 @@ terraform-apply: ## Run `terraform apply` from repo root
 
 .PHONY: terraform-workspace-new
 terraform-workspace-new: ## Creates new Terraform workspace with Concourse remote execution. Run `terraform-workspace-new workspace=<workspace_name>`
-	make bootstrap
+	declare -a workspace=( qa integration preprod production ) \
+	make bootstrap ; \
 	cp terraform.tf jeff.tf && \
-	fly -t aws-concourse execute --config create-workspace.yml --input repo=. -v workspace="$(workspace)"
+	for i in "$${workspace[@]}" ; do \
+		fly -t aws-concourse execute --config create-workspace.yml --input repo=. -v workspace="$$i" ; \
+	done
 	rm jeff.tf

--- a/create-workspace.yml
+++ b/create-workspace.yml
@@ -19,3 +19,4 @@ run:
       terraform init
       terraform workspace new $WORKSPACE
       terraform apply -auto-approve
+  dir: repo

--- a/terraform.tf.j2
+++ b/terraform.tf.j2
@@ -12,7 +12,7 @@ terraform {
 }
 
 provider "aws" {
-  version = "~> 2.66.0"
+  version = "~> 3.12.0"
   region  = "{{terraform.provider_region}}"
 
   assume_role {


### PR DESCRIPTION
- runs job in the correct dir.
- bootstraps so correct files always exist.
- loops each common workspace.
- fly respects `.gitignore`, so creates a temp copy, and removes it after.