### PR TITLE
Remove uncommon tags from common_tags

### DIFF
--- a/terraform.tf.j2
+++ b/terraform.tf.j2
@@ -34,11 +34,8 @@ locals {
     {%- for key, value in common_tags.items() %}
       {{key}} = "{{value}}"
     {%- endfor %}
-    Name         = local.name
     Environment  = local.environment
     Application  = local.name
-    Persistence  = "True"
-    AutoShutdown = "False"
     Costcode     = var.costcode
     Team         = "DataWorks"
   }


### PR DESCRIPTION
Name will differ between resource, and both Persistence and Autoshutdown are only applicable to specific resources.